### PR TITLE
Move openwrt-one TFTP load address after reserved-memory regions

### DIFF
--- a/devices/openwrt-one/default.nix
+++ b/devices/openwrt-one/default.nix
@@ -632,9 +632,8 @@
           tftp = {
             # Should be a segment of free RAM, where the tftp artifact
             # can be stored before unpacking it to the 'hardware.loadAddress'
-            # The 'hardware.loadAddress' is 0x44000000, and the bootlog
-            # suggests it loads the fit to 0x46000000
-            loadAddress = lim.parseInt "0x46000000";
+            # This address is after the reserved-memory regions.
+            loadAddress = lim.parseInt "0x48000000";
           };
           imageFormat = "fit";
           loader.fit.enable = lib.mkDefault true; # override this if you are building tftpboot


### PR DESCRIPTION
I was seeing random filesystem corruption when booting larger images over TFTP, and it turned out to be caused by the image being loaded on top of some reserved-memory regions (see link below).

https://github.com/torvalds/linux/blob/897d54018cc9aa97fd1529ca08a53b429d05a566/arch/arm64/boot/dts/mediatek/mt7981b.dtsi#L72