### PR TITLE
Make Liminix usable as an input to a flake

### DIFF
--- a/bordervm-configuration.nix
+++ b/bordervm-configuration.nix
@@ -1,3 +1,4 @@
+nixpkgs:
 {
   config,
   pkgs,
@@ -65,7 +66,7 @@ in
     };
   };
   imports = [
-    <nixpkgs/nixos/modules/virtualisation/qemu-vm.nix>
+    "${nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix"
   ];
   config = {
     boot.kernelParams = [ "loglevel=9" ];

--- a/default.nix
+++ b/default.nix
@@ -2,15 +2,18 @@
   deviceName ? null,
   device ? (import ./devices/${deviceName}),
   liminix-config ? <liminix-config>,
+  nixpkgs ? <nixpkgs>,
+  system ? builtins.currentSystem,
   borderVmConf ? ./bordervm.conf.nix,
   imageType ? "primary",
 }:
 
 let
-  overlay = import ./overlay.nix;
-  pkgs = import <nixpkgs> (
+  overlay = import ./overlay.nix nixpkgs;
+  pkgs = import nixpkgs (
     device.system
     // {
+      inherit system;
       overlays = [ overlay ];
       config = {
         allowUnsupportedSystem = true; # mipsel
@@ -53,8 +56,8 @@ let
   config = eval.config;
 
   borderVm =
-    ((import <nixpkgs/nixos/lib/eval-config.nix>) {
-      system = builtins.currentSystem;
+    ((import "${nixpkgs}/nixos/lib/eval-config.nix") {
+      inherit system;
       modules = [
         {
           nixpkgs.overlays = [
@@ -64,7 +67,7 @@ let
             })
           ];
         }
-        (import ./bordervm-configuration.nix)
+        (import ./bordervm-configuration.nix nixpkgs)
         borderVmConf
       ];
     }).config.system;
@@ -72,6 +75,7 @@ in
 {
   outputs = config.system.outputs // {
     default = config.system.outputs.${config.hardware.defaultOutput};
+    borderVm = borderVm.build.vm;
     optionsJson =
       let
         o = import ./doc/extract-options.nix {

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,9 +1,10 @@
-final: prev:
+nixpkgs: final: prev:
 let
   isCross = final.stdenv.buildPlatform != final.stdenv.hostPlatform;
   crossOnly = pkg: amendFn: if isCross then (amendFn pkg) else pkg;
   extraPkgs = import ./pkgs/default.nix {
     inherit (final) lib callPackage;
+    inherit nixpkgs;
   };
   inherit (final) fetchpatch lib;
   luaHost =

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,4 +1,4 @@
-{ callPackage, lib }:
+{ callPackage, lib, nixpkgs }:
 let
   typeChecked =
     caller: type: value:
@@ -17,7 +17,9 @@ in
 {
   liminix = {
     builders = {
-      squashfs = callPackage ./liminix-tools/builders/squashfs.nix { };
+      squashfs = callPackage ./liminix-tools/builders/squashfs.nix {
+        inherit nixpkgs;
+      };
       dtb = callPackage ./kernel/dtb.nix { };
       uimage = callPackage ./kernel/uimage.nix { };
       kernel = callPackage ./kernel { };

--- a/pkgs/liminix-tools/builders/squashfs.nix
+++ b/pkgs/liminix-tools/builders/squashfs.nix
@@ -1,6 +1,7 @@
 {
   buildPackages,
   callPackage,
+  nixpkgs,
   pseudofile,
   runCommand,
   writeText,
@@ -9,7 +10,7 @@ filesystem:
 let
   pseudofiles = pseudofile.write "files.pf" filesystem;
 
-  storefs = callPackage <nixpkgs/nixos/lib/make-squashfs.nix> {
+  storefs = callPackage "${nixpkgs}/nixos/lib/make-squashfs.nix" {
     # 1) Every required package is referenced from somewhere
     # outside /nix/store. 2) Every file outside the store is
     # specified by config.filesystem. 3) Therefore, closing over


### PR DESCRIPTION
This change allows Liminix to be used as a non-flake input to a flake by making <nixpkgs> into a default argument.

An example flake that makes use of this is here:
https://github.com/pcc/liminix-flake-demo