### PR TITLE
Avoid dependency on specific PCI addresses in qemu config

### DIFF
--- a/devices/families/qemu.nix
+++ b/devices/families/qemu.nix
@@ -42,11 +42,11 @@
           in
           {
             wan = link.build {
-              devpath = "/devices/pci0000:00/0000:00:12.0/virtio0";
+              devpath = "/bus/virtio/devices/virtio0";
               ifname = "wan";
             };
             lan = link.build {
-              devpath = "/devices/pci0000:00/0000:00:13.0/virtio1";
+              devpath = "/bus/virtio/devices/virtio1";
               ifname = "lan";
             };
 


### PR DESCRIPTION
These addresses will vary depending on the target architecture, so let's name them via /bus instead.