### PR TITLE
Move extraRules to the end of the recursiveUpdate

### DIFF
--- a/modules/firewall/service.nix
+++ b/modules/firewall/service.nix
@@ -94,7 +94,7 @@ let
     icmp6-ratehook = rateHook6;
     icmp4-ratehook = rateHook4;
   }
-  // (lib.recursiveUpdate extraRules (lib.recursiveUpdate sets rules));
+  // (lib.recursiveUpdate (lib.recursiveUpdate sets rules) extraRules);
   script = firewallgen "firewall1.nft" allRules;
   name = "firewall";
   service = longrun {


### PR DESCRIPTION
extraRules is the user-specified ruleset so this allows the user configuration to override the builtin rules.