### PR TITLE
ifwait: Fix flapping on bridged interfaces

### DIFF
--- a/pkgs/ifwait/ifwait.fnl
+++ b/pkgs/ifwait/ifwait.fnl
@@ -52,7 +52,9 @@
 
     (if parameters.service
         (each [e (event-fn)]
-          (if (= e.name parameters.link)
+          (if (and (= e.name parameters.link)
+                   (or (= e.event "newlink") (= e.event "dellink"))
+                   (= e.family "AF_UNSPEC"))
               (toggle-service parameters.service (event-matches? parameters e))))
         (each [e (event-fn)
                &until (event-matches? parameters e)]

--- a/pkgs/netlink-lua/default.nix
+++ b/pkgs/netlink-lua/default.nix
@@ -15,11 +15,11 @@ lua.pkgs.buildLuaPackage {
   src = fetchFromGitHub {
     repo = "lua-netlink";
     owner = "chris2511";
-    rev = "ff8d2012ea42291c87150ba47d4cd89860f7872e";
-    hash = "sha256-tnvFKXxLX+/Q4nJcRDrUfK7bAHBWEANFTBR1PjbQsmQ=";
+    rev = "41e5ced77a5d68239988ac71ca9476ad496dc047";
+    hash = "sha256-z4EK2sKxTdDShhD8e5Z6IeZyQduwOqbXeXmkMhsOTIU=";
   };
 
-  buildPhase = "$CC -shared -l mnl -l lua -o netlink.so src/*.c";
+  buildPhase = "$CC -shared -l mnl -l lua -DVERSION=\\\"1.1.0\\\" -o netlink.so src/*.c";
 
   installPhase = ''
     mkdir -p "$out/lib/lua/${lua.luaversion}"


### PR DESCRIPTION
We use ifwait to monitor a bridged interface so we can add or remove it to the bridge by bringing the associated service up or down. However, bridge related netlink events can cause ifwait to incorrectly consider the interface to have gone down. For example, nlmsg_type=RTM_DELLINK with ifi_family=AF_BRIDGE, which is triggered by removing an interface from a bridge, and does not indicate that the interface itself was removed. Because a later RTM_NEWLINK will indicate that the link is still up, ifwait will bring the service down and then up again, triggering more netlink messages that keep ifwait in an infinite loop.

Fix it by checking specifically for RTM_NEWLINK and RTM_DELLINK messages with ifi_family=AF_UNSPEC, which indicates an event related to the interface itself.