### PR TITLE
Fix race between lease-acquired and dependent services

### DIFF
--- a/modules/dhcp4c/client.nix
+++ b/modules/dhcp4c/client.nix
@@ -80,7 +80,9 @@ longrun {
     (in_outputs ${controlled-name}
      cp $(output_path ${service})/* .
      )
+    echo > /proc/self/fd/10
     while sleep 86400 ; do true ; done
   '';
   controller = watcher;
+  notification-fd = 10;
 }


### PR DESCRIPTION
We use s6-rc-up-tree to bring up all services depending on lease-acquired, but there's a race between copying the lease information into the lease-acquired service directory and dependent services reading from the service directory. Fix it by using the notification-fd mechanism to notify s6 when the files are copied.