### PR TITLE
dnsmasq: Pass --bind-interfaces

### DIFF
--- a/modules/dnsmasq/service.nix
+++ b/modules/dnsmasq/service.nix
@@ -48,6 +48,7 @@ longrun {
     --domain=${domain} \
     --group=${group} \
     --interface=$(output ${interface} ifname) \
+    --bind-interfaces \
     ${lib.concatStringsSep " " (builtins.map (r: "--dhcp-range=${r}") ranges)} \
     ${lib.concatStringsSep " " (builtins.map (r: "--server=${r}") upstreams)} \
     --keep-in-foreground \


### PR DESCRIPTION
This allows users to run another DNS server, such as unbound, and have dnsmasq use it as the upstream.