### PR TITLE
ifwait: React to interface up by bringing up the service tree

### DIFF
--- a/pkgs/ifwait/default.nix
+++ b/pkgs/ifwait/default.nix
@@ -3,6 +3,8 @@
   writeFennel,
   runCommand,
   anoia,
+  lualinux,
+  s6-rc-up-tree,
 }:
 runCommand "ifwait" { } ''
   mkdir -p $out/bin
@@ -10,7 +12,9 @@ runCommand "ifwait" { } ''
     writeFennel "ifwait" {
       packages = [
         anoia
+        lualinux
         netlink-lua
+        s6-rc-up-tree
       ];
     } ./ifwait.fnl
   } $out/bin/ifwait

--- a/pkgs/ifwait/ifwait.fnl
+++ b/pkgs/ifwait/ifwait.fnl
@@ -37,7 +37,7 @@
   (when (not (= up wanted?))
     (set up
          (if wanted?
-             (pcall system (.. "s6-rc -b -u change " service))
+             (pcall system (.. "s6-rc-up-tree " service))
              (not (pcall system (.. "s6-rc -b -d change " service)))))
     ))
 


### PR DESCRIPTION
This allows a system to be configured to dynamically bring up services associated with an interface. For example, attaching a USB ethernet adapter could trigger starting a DHCP client and an additional default route for failover to an additional upstream.