### PR TITLE
kmodloader: Filter out builtin lines from modprobe output

### DIFF
--- a/pkgs/kmodloader/default.nix
+++ b/pkgs/kmodloader/default.nix
@@ -28,7 +28,7 @@ let
         depmod -b . 0.0
 
         (for i in ${lib.concatStringsSep " " targets}; do
-          modprobe -S 0.0 -d  $NIX_BUILD_TOP --show-depends $i | sed "s,^insmod $NIX_BUILD_TOP/lib/modules/0.0/,,g"
+          modprobe -S 0.0 -d  $NIX_BUILD_TOP --show-depends $i | grep "^insmod" | sed "s,^insmod $NIX_BUILD_TOP/lib/modules/0.0/,,g"
         done) | awk '!a[$0]++' > load-order
 
         mkdir $out


### PR DESCRIPTION
modprobe will print "builtin" lines for modules that are statically linked into the kernel, which confuses this shell pipeline. Fix it by adding a grep for "^insmod".