### PR TITLE
Stop unnecessarily removing sections from the kernel binary

### DIFF
--- a/modules/outputs/tftpboot.nix
+++ b/modules/outputs/tftpboot.nix
@@ -85,7 +85,7 @@ in
           cmdline = concatStringsSep " " config.boot.commandLine;
           objcopy = "${pkgs.stdenv.cc.bintools.targetPrefix}objcopy";
           stripAndZip = ''
-            ${objcopy} -O binary -R .reginfo -R .notes -R .note -R .comment -R .mdebug -R .note.gnu.build-id -S vmlinux.elf vmlinux.bin
+            ${objcopy} -O binary -S vmlinux.elf vmlinux.bin
             rm -f vmlinux.bin.lzma ; lzma -k -z  vmlinux.bin
           '';
         in

--- a/pkgs/kernel/uimage.nix
+++ b/pkgs/kernel/uimage.nix
@@ -9,7 +9,7 @@ let
   objcopy = "${stdenv.cc.bintools.targetPrefix}objcopy";
   arch = stdenv.hostPlatform.linuxArch;
   stripAndZip = ''
-    ${objcopy} -O binary -R .reginfo -R .notes -R .note -R .comment -R .mdebug -R .note.gnu.build-id -S vmlinux.elf vmlinux.bin
+    ${objcopy} -O binary -S vmlinux.elf vmlinux.bin
     rm -f vmlinux.bin.lzma ; lzma -k -z  vmlinux.bin
   '';
 in


### PR DESCRIPTION
We just need -S here which removes non-SHF_ALLOC sections. SHF_ALLOC sections are generally required to be in the kernel image, and can't be removed (in the sense of shrinking the binary) by a tool like objcopy because that would alter the section layout which is fixed by the linker. objcopy was "removing" these sections by replacing them with zeros, so this wasn't reducing the size of the kernel anyway.

In particular, this command was removing the .notes section containing the build ID which is readable from userspace via /sys/kernel/notes and may be used for symbolization on the host.