### PR TITLE
Enable CONFIG_HIGH_RES_TIMERS in the default kernel config

### DIFF
--- a/modules/kernel/default.nix
+++ b/modules/kernel/default.nix
@@ -130,6 +130,9 @@ in
         # at boot time unless we disable trying to call it.
         # https://lkml.org/lkml/2013/8/5/175
         FW_LOADER_USER_HELPER = "n";
+
+        # SPI NAND access may be slow without this.
+        HIGH_RES_TIMERS = "y";
       };
     };
   };


### PR DESCRIPTION
At least on OpenWrt One, the kernel default of
CONFIG_HIGH_RES_TIMERS=n causes slow SPI NAND access speeds. See: https://lore.kernel.org/all/CAPQLkRit9bRH2gnSpvt60evu31T=1YNFdTFH2emS6RSsY=eDJQ@mail.gmail.com/

Since this doesn't seem to be an inherently device-specific issue, and leaving it disabled may cause other performance problems that are difficult to debug, enable it in the default config.