### PR TITLE
Add OpenWrt One bootloader output

### DIFF
--- a/devices/openwrt-one/default.nix
+++ b/devices/openwrt-one/default.nix
@@ -79,6 +79,54 @@
     you could also install directly from U-Boot:
 
     https://github.com/u-boot/u-boot/blob/master/doc/README.ubi
+
+    === Flashing the bootloader
+
+    Flashing the bootloader (U-Boot and Trusted Firmware-A) is not
+    currently necessary, but may become necessary in at least  some
+    configurations in a future version of Liminix.
+
+    Currently, the main advantage of flashing the bootloader is that it
+    enables KASLR support in Linux. It also avoids the need to manually
+    run the `fw_setenv` commands, as the necessary environment variable
+    update is built into the U-Boot binary.
+
+    The bootloader can be built via the `u-boot` output, e.g.:
+
+    [source,console]
+    ----
+    $ nix-build -I liminix-config=./my-configuration.nix --arg device
+    "import ./devices/openwrt-one" -A outputs.u-boot
+    ----
+
+    To flash the bootloader, set up a TFTP server, run the commands in
+    `result/flash.scr` from U-Boot and reboot.
+
+    The `u-boot` output can also be used in the following ways:
+
+    1. Chain load U-Boot from a running U-Boot. This can be used to
+       test changes to U-Boot without flashing the bootloader. To do this,
+       run the commands in `result/boot.scr` from U-Boot.
+
+    2. Send the bootloader over the serial port and boot it. This can
+       be used to test changes to U-Boot or Trusted Firmware-A without
+       flashing the bootloader, or to recover from flashing a broken
+       bootloader. To do this, remove power from the target device,
+       start the command `result/uartboot.sh` passing as an argument the
+       path to the device node for the serial port (e.g. `/dev/ttyACM0`),
+       and then apply power.
+
+       U-Boot will start running on the target device as soon as
+       `uartboot.sh` exits, so you may need to interrupt autoboot to
+       issue your testing or recovery commands. To do this, you can
+       issue a command such as the following (substitute `tio` with your
+       preferred tool for connecting to the serial port), and be ready
+       to interrupt autoboot when your serial port tool starts:
+
+    [source,console]
+    ----
+    $ result/uartboot.sh /dev/ttyACM0 && tio /dev/ttyACM0
+    ----
   '';
 
   system = {
@@ -748,6 +796,21 @@
                 };
               };
           };
+        system.outputs.u-boot = openwrt.buildMediatekBootloader rec {
+          inherit (config.boot.tftp) loadAddress serverip ipaddr;
+          ubootDefconfig = "mt7981_openwrt-one-spi-nand_defconfig";
+          ubootenv = {
+            boot_production = "led white on ; ubifsmount ubi0:liminix && ubifsload \${loadaddr} boot/fit && bootm \${loadaddr}";
+          };
+          tfaPlatform = "mt7981";
+          tfaMakeFlags = [
+            "BOOT_DEVICE=spim-nand"
+            "DRAM_USE_DDR4=1"
+            "HAVE_DRAM_OBJ_FILE=yes"
+            "UBI=1"
+            "OVERRIDE_UBI_START_ADDR=0x100000"
+          ];
+        };
       };
     };
 }

--- a/devices/qemu-aarch64/default.nix
+++ b/devices/qemu-aarch64/default.nix
@@ -27,7 +27,7 @@
   installer = "vmroot";
 
   module =
-    { config, lim, ... }:
+    { config, lim, pkgs, ... }:
     {
       imports = [
         ../../modules/arch/aarch64.nix
@@ -53,5 +53,6 @@
           loadAddress = addr;
           entryPoint = addr;
         };
+      system.outputs.u-boot = pkgs.ubootQemuAarch64;
     };
 }

--- a/modules/arch/aarch64.nix
+++ b/modules/arch/aarch64.nix
@@ -18,6 +18,5 @@
       # USE_OF = "y";
     };
     hardware.ram.startAddress = lim.parseInt "0x40000000";
-    system.outputs.u-boot = pkgs.ubootQemuAarch64;
   };
 }

--- a/pkgs/openwrt/0001-Upgrade-psci-compatible-to-1.0.patch
+++ b/pkgs/openwrt/0001-Upgrade-psci-compatible-to-1.0.patch
@@ -1,0 +1,26 @@
+From 2267b7c8bbfaf29b7eb5d8bd1d08277d84d57d77 Mon Sep 17 00:00:00 2001
+From: Peter Collingbourne <peter@pcc.me.uk>
+Date: Wed, 20 May 2026 04:02:07 -0700
+Subject: [PATCH] Upgrade psci compatible to 1.0
+
+This enables U-Boot to probe for PSCI features such as TRNG.
+---
+ arch/arm/dts/mt7981.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/mt7981.dtsi b/arch/arm/dts/mt7981.dtsi
+index 26e7486eb88..3365733bc21 100644
+--- a/arch/arm/dts/mt7981.dtsi
++++ b/arch/arm/dts/mt7981.dtsi
+@@ -34,7 +34,7 @@
+ 	};
+ 
+ 	psci {
+-		compatible  = "arm,psci-0.2";
++		compatible  = "arm,psci-1.0";
+ 		method      = "smc";
+ 	};
+ 
+-- 
+2.54.0
+

--- a/pkgs/openwrt/0001-fs-ubifs-fix-bugs-involving-symlinks-in-ubifs_findfi.patch
+++ b/pkgs/openwrt/0001-fs-ubifs-fix-bugs-involving-symlinks-in-ubifs_findfi.patch
@@ -1,0 +1,157 @@
+From d5888d509cc43942ec98d993f2d129f5c8ddc432 Mon Sep 17 00:00:00 2001
+From: Peter Collingbourne <peter@pcc.me.uk>
+Date: Tue, 5 May 2026 03:38:16 -0700
+Subject: [PATCH] fs: ubifs: fix bugs involving symlinks in ubifs_findfile
+
+When encountering a symlink pointing to an absolute path, ubifs_findfile
+would return the target of the symlink as the result instead of resolving
+any following components in the original path. Fix it by following the
+same code path that is used for relative paths except that we set the
+next inode to the root if we see a leading slash.
+
+The existing code used memcpy and sprintf to copy the symlink target
+into a fixed size stack buffer and was therefore vulnerable to buffer
+overflows with a sufficiently long symlink target. Fix it by using a
+heap buffer for the temporary path during path resolution.
+
+Signed-off-by: Peter Collingbourne <peter@pcc.me.uk>
+Fixes: 9d7952e4c636 ("ubifs: Add support for looking up directory and relative symlinks")
+---
+ fs/ubifs/ubifs.c | 70 +++++++++++++++++++++++++++++++-----------------
+ 1 file changed, 45 insertions(+), 25 deletions(-)
+
+diff --git a/fs/ubifs/ubifs.c b/fs/ubifs/ubifs.c
+index b0cc0d2e1b2..aafbd01a028 100644
+--- a/fs/ubifs/ubifs.c
++++ b/fs/ubifs/ubifs.c
+@@ -505,26 +505,32 @@ static unsigned long ubifs_findfile(struct super_block *sb, char *filename)
+ {
+ 	int ret;
+ 	char *next;
+-	char fpath[128];
+-	char symlinkpath[128];
+-	char *name = fpath;
++	char *buf;
++	char *name;
+ 	unsigned long root_inum = 1;
+ 	unsigned long inum;
+ 	int symlink_count = 0; /* Don't allow symlink recursion */
+-	char link_name[64];
+-
+-	strcpy(fpath, filename);
++	size_t filenamelen;
+ 
+ 	/* Remove all leading slashes */
+-	while (*name == '/')
+-		name++;
++	while (*filename == '/')
++		filename++;
++
++	filenamelen = strlen(filename);
++	buf = kmalloc(filenamelen + 1, GFP_NOFS);
++	if (!buf)
++		return -ENOMEM;
++	memcpy(buf, filename, filenamelen + 1);
++	name = buf;
+ 
+ 	/*
+ 	 * Handle root-direcoty ('/')
+ 	 */
+ 	inum = root_inum;
+-	if (!name || *name == '\0')
++	if (!name || *name == '\0') {
++		kfree(buf);
+ 		return inum;
++	}
+ 
+ 	for (;;) {
+ 		struct inode *inode;
+@@ -537,41 +543,53 @@ static unsigned long ubifs_findfile(struct super_block *sb, char *filename)
+ 			while (*next == '/')
+ 				*(next++) = '\0';
+ 		}
+-
+ 		ret = ubifs_finddir(sb, name, root_inum, &inum);
+-		if (!ret)
++		if (!ret) {
++			kfree(buf);
+ 			return 0;
++		}
+ 		inode = ubifs_iget(sb, inum);
+ 
+-		if (!inode)
++		if (!inode) {
++			kfree(buf);
+ 			return 0;
++		}
+ 		ui = ubifs_inode(inode);
+ 
+ 		if ((inode->i_mode & S_IFMT) == S_IFLNK) {
+-			char buf[128];
++			size_t newbufsize;
++			char *newbuf;
++			char *linkdata = ui->data;
++			size_t linklen = ui->data_len;
+ 
+ 			/* We have some sort of symlink recursion, bail out */
+ 			if (symlink_count++ > 8) {
+ 				ubifs_iput(inode);
+ 				printf("Symlink recursion, aborting\n");
++				kfree(buf);
+ 				return 0;
+ 			}
+-			memcpy(link_name, ui->data, ui->data_len);
+-			link_name[ui->data_len] = '\0';
+ 
+-			if (link_name[0] == '/') {
+-				/* Absolute path, redo everything without
+-				 * the leading slash */
+-				next = name = link_name + 1;
++			while (linklen && *linkdata == '/') {
++				/* Absolute path, i.e. relative to root. */
+ 				root_inum = 1;
++				linkdata++;
++				linklen--;
++			}
++			newbufsize =
++				linklen + 1 + (next ? strlen(next) : 0) + 1;
++			newbuf = kmalloc(newbufsize, GFP_NOFS);
++			if (!newbuf) {
++				kfree(buf);
+ 				ubifs_iput(inode);
+-				continue;
++				return -ENOMEM;
+ 			}
+-			/* Relative to cur dir */
+-			sprintf(buf, "%s/%s",
+-					link_name, next == NULL ? "" : next);
+-			memcpy(symlinkpath, buf, sizeof(buf));
+-			next = name = symlinkpath;
++
++			memcpy(newbuf, linkdata, linklen);
++			sprintf(newbuf + linklen, "/%s", next ?: "");
++			kfree(buf);
++			buf = newbuf;
++			name = newbuf;
+ 			ubifs_iput(inode);
+ 			continue;
+ 		}
+@@ -583,6 +601,7 @@ static unsigned long ubifs_findfile(struct super_block *sb, char *filename)
+ 		/* Found the node!  */
+ 		if (!next || *next == '\0') {
+ 			ubifs_iput(inode);
++			kfree(buf);
+ 			return inum;
+ 		}
+ 
+@@ -590,6 +609,7 @@ static unsigned long ubifs_findfile(struct super_block *sb, char *filename)
+ 		name = next;
+ 	}
+ 
++	kfree(buf);
+ 	return 0;
+ }
+ 
+-- 
+2.54.0
+

--- a/pkgs/openwrt/0001-mediatek-mt7981-mt7986-mt7987-mt7988-add-SMCCC-TRNG-.patch
+++ b/pkgs/openwrt/0001-mediatek-mt7981-mt7986-mt7987-mt7988-add-SMCCC-TRNG-.patch
@@ -1,0 +1,216 @@
+From 476cf6629f7675c9857b59458851dda64de88343 Mon Sep 17 00:00:00 2001
+From: Peter Collingbourne <peter@pcc.me.uk>
+Date: Wed, 20 May 2026 01:31:38 -0700
+Subject: [PATCH] mediatek: mt7981, mt7986, mt7987, mt7988: add SMCCC TRNG
+ support
+
+This will allow U-Boot to provide a KASLR seed to Linux. U-Boot only
+supports the standard SMCCC TRNG interface and not the MTK-specific one.
+
+Tested on MT7981 only.
+
+Signed-off-by: Peter Collingbourne <peter@pcc.me.uk>
+---
+ plat/mediatek/apsoc_common/bl31/mtk_sip_svc.h         |  1 +
+ .../apsoc_common/drivers/trng/v1/{rng.c => trng.c}    | 11 +++++++++++
+ .../apsoc_common/drivers/trng/v2/{rng.c => trng.c}    | 11 +++++++++++
+ plat/mediatek/mt7981/bl31/bl31.mk                     |  3 ++-
+ plat/mediatek/mt7981/platform.mk                      |  2 ++
+ plat/mediatek/mt7986/bl31/bl31.mk                     |  3 ++-
+ plat/mediatek/mt7986/platform.mk                      |  2 ++
+ plat/mediatek/mt7987/bl31/bl31.mk                     |  3 ++-
+ plat/mediatek/mt7987/platform.mk                      |  2 ++
+ plat/mediatek/mt7988/bl31/bl31.mk                     |  3 ++-
+ plat/mediatek/mt7988/platform.mk                      |  2 ++
+ 11 files changed, 39 insertions(+), 4 deletions(-)
+ rename plat/mediatek/apsoc_common/drivers/trng/v1/{rng.c => trng.c} (88%)
+ rename plat/mediatek/apsoc_common/drivers/trng/v2/{rng.c => trng.c} (91%)
+
+diff --git a/plat/mediatek/apsoc_common/bl31/mtk_sip_svc.h b/plat/mediatek/apsoc_common/bl31/mtk_sip_svc.h
+index 6c7ef9bba..7060bd221 100644
+--- a/plat/mediatek/apsoc_common/bl31/mtk_sip_svc.h
++++ b/plat/mediatek/apsoc_common/bl31/mtk_sip_svc.h
+@@ -7,6 +7,7 @@
+ #define MTK_SIP_SVC_H
+ 
+ #include <stdint.h>
++#include <common/runtime_svc.h>
+ #include <lib/smccc.h>
+ #include <lib/utils_def.h>
+ 
+diff --git a/plat/mediatek/apsoc_common/drivers/trng/v1/rng.c b/plat/mediatek/apsoc_common/drivers/trng/v1/trng.c
+similarity index 88%
+rename from plat/mediatek/apsoc_common/drivers/trng/v1/rng.c
+rename to plat/mediatek/apsoc_common/drivers/trng/v1/trng.c
+index 6e6977ac2..1d4e76b28 100644
+--- a/plat/mediatek/apsoc_common/drivers/trng/v1/rng.c
++++ b/plat/mediatek/apsoc_common/drivers/trng/v1/trng.c
+@@ -68,3 +68,14 @@ uint32_t plat_get_rnd(uint32_t *val)
+ 
+ 	return ret;
+ }
++
++bool plat_get_entropy(uint64_t *val)
++{
++	uint32_t lo, hi;
++
++	if (plat_get_rnd(&lo) || plat_get_rnd(&hi))
++		return false;
++
++	*val = (((uint64_t)hi) << 32) | lo;
++	return true;
++}
+diff --git a/plat/mediatek/apsoc_common/drivers/trng/v2/rng.c b/plat/mediatek/apsoc_common/drivers/trng/v2/trng.c
+similarity index 91%
+rename from plat/mediatek/apsoc_common/drivers/trng/v2/rng.c
+rename to plat/mediatek/apsoc_common/drivers/trng/v2/trng.c
+index dbcad8cc5..ed784cb58 100644
+--- a/plat/mediatek/apsoc_common/drivers/trng/v2/rng.c
++++ b/plat/mediatek/apsoc_common/drivers/trng/v2/trng.c
+@@ -87,3 +87,14 @@ uint32_t plat_get_rnd(uint32_t *val)
+ 
+ 	return ret;
+ }
++
++bool plat_get_entropy(uint64_t *val)
++{
++	uint32_t lo, hi;
++
++	if (plat_get_rnd(&lo) || plat_get_rnd(&hi))
++		return false;
++
++	*val = (((uint64_t)hi) << 32) | lo;
++	return true;
++}
+diff --git a/plat/mediatek/mt7981/bl31/bl31.mk b/plat/mediatek/mt7981/bl31/bl31.mk
+index 42ba3e8f0..28ba620c2 100644
+--- a/plat/mediatek/mt7981/bl31/bl31.mk
++++ b/plat/mediatek/mt7981/bl31/bl31.mk
+@@ -19,7 +19,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				lib/cpus/aarch64/cortex_a53.S			\
+ 				plat/common/plat_gicv3.c			\
+ 				$(APSOC_COMMON)/drivers/uart/aarch64/hsuart.S	\
+-				$(APSOC_COMMON)/drivers/trng/v2/rng.c		\
++				$(APSOC_COMMON)/drivers/trng/v2/trng.c		\
+ 				$(APSOC_COMMON)/drivers/wdt/mtk_wdt.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_sip_svc.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_boot_next.c		\
+@@ -28,6 +28,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				$(APSOC_COMMON)/bl31/plat_topology.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_gic_v3.c		\
+ 				$(APSOC_COMMON)/bl31/plat_pm.c			\
++				$(MTK_PLAT)/drivers/rng/rng.c			\
+ 				$(MTK_PLAT_SOC)/aarch64/plat_helpers.S		\
+ 				$(MTK_PLAT_SOC)/aarch64/platform_common.c	\
+ 				$(MTK_PLAT_SOC)/bl31/bl31_plat_setup.c		\
+diff --git a/plat/mediatek/mt7981/platform.mk b/plat/mediatek/mt7981/platform.mk
+index 5c105d211..4fe95e2c7 100644
+--- a/plat/mediatek/mt7981/platform.mk
++++ b/plat/mediatek/mt7981/platform.mk
+@@ -8,6 +8,8 @@ MTK_PLAT		:=	plat/mediatek
+ MTK_PLAT_SOC		:=	$(MTK_PLAT)/$(PLAT)
+ APSOC_COMMON		:=	$(MTK_PLAT)/apsoc_common
+ 
++TRNG_SUPPORT		:=	1
++
+ # Enable workarounds for selected Cortex-A53 erratas.
+ ERRATA_A53_826319	:=	1
+ ERRATA_A53_836870	:=	1
+diff --git a/plat/mediatek/mt7986/bl31/bl31.mk b/plat/mediatek/mt7986/bl31/bl31.mk
+index 7ab7a5cab..2fa6e75f9 100644
+--- a/plat/mediatek/mt7986/bl31/bl31.mk
++++ b/plat/mediatek/mt7986/bl31/bl31.mk
+@@ -27,7 +27,8 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				$(APSOC_COMMON)/bl31/plat_topology.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_gic_v3.c		\
+ 				$(APSOC_COMMON)/bl31/plat_pm.c			\
+-				$(APSOC_COMMON)/drivers/trng/v1/rng.c		\
++				$(APSOC_COMMON)/drivers/trng/v1/trng.c		\
++				$(MTK_PLAT)/drivers/rng/rng.c			\
+ 				$(MTK_PLAT_SOC)/aarch64/plat_helpers.S		\
+ 				$(MTK_PLAT_SOC)/aarch64/platform_common.c	\
+ 				$(MTK_PLAT_SOC)/bl31/bl31_plat_setup.c		\
+diff --git a/plat/mediatek/mt7986/platform.mk b/plat/mediatek/mt7986/platform.mk
+index ba11e7898..b5a43cb0d 100644
+--- a/plat/mediatek/mt7986/platform.mk
++++ b/plat/mediatek/mt7986/platform.mk
+@@ -8,6 +8,8 @@ MTK_PLAT		:=	plat/mediatek
+ MTK_PLAT_SOC		:=	$(MTK_PLAT)/$(PLAT)
+ APSOC_COMMON		:=	$(MTK_PLAT)/apsoc_common
+ 
++TRNG_SUPPORT		:=	1
++
+ # Enable workarounds for selected Cortex-A53 erratas.
+ ERRATA_A53_826319	:=	1
+ ERRATA_A53_836870	:=	1
+diff --git a/plat/mediatek/mt7987/bl31/bl31.mk b/plat/mediatek/mt7987/bl31/bl31.mk
+index 96ad51432..719b141ca 100644
+--- a/plat/mediatek/mt7987/bl31/bl31.mk
++++ b/plat/mediatek/mt7987/bl31/bl31.mk
+@@ -19,7 +19,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				$(CPU_SOURCES)					\
+ 				plat/common/plat_gicv3.c			\
+ 				$(APSOC_COMMON)/drivers/uart/aarch64/hsuart.S	\
+-				$(APSOC_COMMON)/drivers/trng/v2/rng.c		\
++				$(APSOC_COMMON)/drivers/trng/v2/trng.c		\
+ 				$(APSOC_COMMON)/drivers/wdt/mtk_wdt.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_sip_svc.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_boot_next.c		\
+@@ -28,6 +28,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				$(APSOC_COMMON)/bl31/plat_topology.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_gic_v3.c		\
+ 				$(APSOC_COMMON)/bl31/plat_pm.c			\
++				$(MTK_PLAT)/drivers/rng/rng.c			\
+ 				$(MTK_PLAT_SOC)/aarch64/plat_helpers.S		\
+ 				$(MTK_PLAT_SOC)/aarch64/platform_common.c	\
+ 				$(MTK_PLAT_SOC)/bl31/bl31_plat_setup.c		\
+diff --git a/plat/mediatek/mt7987/platform.mk b/plat/mediatek/mt7987/platform.mk
+index 1b0d4bedd..82913b9d5 100644
+--- a/plat/mediatek/mt7987/platform.mk
++++ b/plat/mediatek/mt7987/platform.mk
+@@ -8,6 +8,8 @@ MTK_PLAT		:=	plat/mediatek
+ MTK_PLAT_SOC		:=	$(MTK_PLAT)/$(PLAT)
+ APSOC_COMMON		:=	$(MTK_PLAT)/apsoc_common
+ 
++TRNG_SUPPORT		:=	1
++
+ ifeq ($(FPGA),1)
+ MTK_PLAT_SOC_BSP	:=	$(MTK_PLAT_SOC)/fpga
+ include $(MTK_PLAT_SOC_BSP)/fpga.mk
+diff --git a/plat/mediatek/mt7988/bl31/bl31.mk b/plat/mediatek/mt7988/bl31/bl31.mk
+index 5b5b3cdc1..957a992f8 100644
+--- a/plat/mediatek/mt7988/bl31/bl31.mk
++++ b/plat/mediatek/mt7988/bl31/bl31.mk
+@@ -19,7 +19,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				lib/cpus/aarch64/cortex_a73.S			\
+ 				plat/common/plat_gicv3.c			\
+ 				$(APSOC_COMMON)/drivers/uart/aarch64/hsuart.S	\
+-				$(APSOC_COMMON)/drivers/trng/v2/rng.c		\
++				$(APSOC_COMMON)/drivers/trng/v2/trng.c		\
+ 				$(APSOC_COMMON)/drivers/wdt/mtk_wdt.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_sip_svc.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_boot_next.c		\
+@@ -28,6 +28,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
+ 				$(APSOC_COMMON)/bl31/plat_topology.c		\
+ 				$(APSOC_COMMON)/bl31/mtk_gic_v3.c		\
+ 				$(APSOC_COMMON)/bl31/plat_pm.c			\
++				$(MTK_PLAT)/drivers/rng/rng.c			\
+ 				$(MTK_PLAT_SOC)/aarch64/plat_helpers.S		\
+ 				$(MTK_PLAT_SOC)/aarch64/platform_common.c	\
+ 				$(MTK_PLAT_SOC)/bl31/bl31_plat_setup.c		\
+diff --git a/plat/mediatek/mt7988/platform.mk b/plat/mediatek/mt7988/platform.mk
+index 6696b0270..56b4d98c4 100644
+--- a/plat/mediatek/mt7988/platform.mk
++++ b/plat/mediatek/mt7988/platform.mk
+@@ -8,6 +8,8 @@ MTK_PLAT		:=	plat/mediatek
+ MTK_PLAT_SOC		:=	$(MTK_PLAT)/$(PLAT)
+ APSOC_COMMON		:=	$(MTK_PLAT)/apsoc_common
+ 
++TRNG_SUPPORT		:=	1
++
+ # Enable workarounds for selected Cortex-A73 erratas.
+ ERRATA_A73_852427	:=	1
+ ERRATA_A73_855423	:=	1
+-- 
+2.54.0
+

--- a/pkgs/openwrt/2512.nix
+++ b/pkgs/openwrt/2512.nix
@@ -1,5 +1,6 @@
 {
   fetchFromGitHub,
+  pkgs,
   pkgsBuildBuild,
   lib,
   cpio
@@ -24,14 +25,7 @@ let
   };
   kernelVersion = "6.12.85";
   kernelSeries = lib.versions.majorMinor kernelVersion;
-  doPatch = family: ''
-    tar -C ${src}/target/linux/generic/files -cf - . | tar xpf -
-    chmod -R u+w .
-    tar -C ${src}/target/linux/${family}/files -cf - . | tar xpf -
-    chmod -R u+w .
-    test -d ${src}/target/linux/${family}/files-${kernelSeries}/ && ( tar -C ${src}/target/linux/${family}/files-${kernelSeries} -cf - . | tar xpf -)
-    chmod -R u+w .
-
+  patchFuncs = ''
     ensure_patch() {
       echo Applying $1
       # skip patches which are already applied by testing if they
@@ -45,24 +39,36 @@ let
          ensure_patch $i
       done
     }
+  '';
+  doPatch = family: ''
+        tar -C ${src}/target/linux/generic/files -cf - . | tar xpf -
+        chmod -R u+w .
+        tar -C ${src}/target/linux/${family}/files -cf - . | tar xpf -
+        chmod -R u+w .
+        test -d ${src}/target/linux/${family}/files-${kernelSeries}/ && ( tar -C ${src}/target/linux/${family}/files-${kernelSeries} -cf - . | tar xpf -)
+        chmod -R u+w .
 
-    patches ${src}/target/linux/generic/backport-${kernelSeries}/*.patch
-    patches ${src}/target/linux/generic/pending-${kernelSeries}/*.patch
-    patches ${src}/target/linux/generic/hack-${kernelSeries}/*.patch
-    patches ${src}/target/linux/${family}/patches-${kernelSeries}/*.patch
-    ${lib.optionalString (family == "mediatek") "patches ${./fixup-731-v6.18-net-mediatek-wed-Introduce-MT7992-WED-support-to-MT7.patch}"}
+        ${patchFuncs}
 
-    for kconfig in $(find drivers/net/wireless/ -name Kconfig); do
-      sed -i.bak -E -e '/^((\s+))tristate/a\
-\tdepends on m'  $kconfig
-    done
+        patches ${src}/target/linux/generic/backport-${kernelSeries}/*.patch
+        patches ${src}/target/linux/generic/pending-${kernelSeries}/*.patch
+        patches ${src}/target/linux/generic/hack-${kernelSeries}/*.patch
+        patches ${src}/target/linux/${family}/patches-${kernelSeries}/*.patch
+        ${lib.optionalString (
+          family == "mediatek"
+        ) "patches ${./fixup-731-v6.18-net-mediatek-wed-Introduce-MT7992-WED-support-to-MT7.patch}"}
 
-    mkdir backport_patches
-    for f in ${oldSrc}/package/kernel/mac80211/patches/*.*; do
-      out=backport_patches/`basename $f`
-      sed < $f 's/CPTCFG_/CONFIG_/g' > $out
-      ensure_patch $out
-    done
+        for kconfig in $(find drivers/net/wireless/ -name Kconfig); do
+          sed -i.bak -E -e '/^((\s+))tristate/a\
+    \tdepends on m'  $kconfig
+        done
+
+        mkdir backport_patches
+        for f in ${oldSrc}/package/kernel/mac80211/patches/*.*; do
+          out=backport_patches/`basename $f`
+          sed < $f 's/CPTCFG_/CONFIG_/g' > $out
+          ensure_patch $out
+        done
   '';
 in
 {
@@ -103,4 +109,134 @@ in
       esac
     done
   '';
+
+  buildMediatekBootloader =
+    {
+      ubootDefconfig,
+      ubootenv,
+      tfaPlatform,
+      tfaMakeFlags,
+      loadAddress,
+      serverip,
+      ipaddr,
+    }:
+    let
+      ubootVersion = "2025.10";
+      ubootSrc = pkgsBuildBuild.fetchurl {
+        url = "https://ftp.denx.de/pub/u-boot/u-boot-${ubootVersion}.tar.bz2";
+        hash = "sha256-tPAyhI5WzI8hOtWfkTLAhNu7YyvCkXbQJOWCIODv30o=";
+      };
+      uboot = pkgs.buildUBoot {
+        defconfig = ubootDefconfig;
+        extraConfig = ''
+          CONFIG_DM_RNG=y
+          CONFIG_RNG_SMCCC_TRNG=y
+          CONFIG_ARM_SMCCC_FEATURES=y
+        '';
+        src = ubootSrc;
+        version = ubootVersion;
+        extraMeta.platforms = [ "aarch64-linux" ];
+        prePatch = ''
+          ${patchFuncs}
+
+          patches ${src}/package/boot/uboot-mediatek/patches/*.patch
+          patches ${./0001-fs-ubifs-fix-bugs-involving-symlinks-in-ubifs_findfi.patch}
+          patches ${./0001-Upgrade-psci-compatible-to-1.0.patch}
+
+          configPath=$(grep CONFIG_ENV_DEFAULT_ENV_TEXT_FILE= configs/${ubootDefconfig} | cut -d\" -f2)
+          ${lib.concatStrings (
+            lib.mapAttrsToList (
+              name: value: "echo ${lib.escapeShellArg name}=${lib.escapeShellArg value} >> $configPath\n"
+            ) ubootenv
+          )}
+        '';
+        filesToInstall = [ "u-boot.bin" ];
+      };
+
+      armTrustedFirmwareSrc = fetchFromGitHub {
+        owner = "mtk-openwrt";
+        repo = "arm-trusted-firmware";
+        rev = "78a0dfd927bb00ce973a1f8eb4079df0f755887a";
+        hash = "sha256-m9ApkBVf0I11rNg68vxofGRJ+BcnlM6C+Zrn8TfMvbY=";
+      };
+      applyArmTrustedFirmwarePatches = ''
+        ${patchFuncs}
+
+        patches ${src}/package/boot/arm-trusted-firmware-mediatek/patches/*.patch
+        patches ${./0001-mediatek-mt7981-mt7986-mt7987-mt7988-add-SMCCC-TRNG-.patch}
+      '';
+      armTrustedFirmwareVersion = "2025-07-11";
+      armTrustedFirmwareFlash = pkgs.buildArmTrustedFirmware rec {
+        src = armTrustedFirmwareSrc;
+        version = armTrustedFirmwareVersion;
+        prePatch = applyArmTrustedFirmwarePatches;
+        extraMakeFlags = tfaMakeFlags ++ [
+          "bl2"
+          "bl31"
+        ];
+        platform = tfaPlatform;
+        extraMeta.platforms = [ "aarch64-linux" ];
+        filesToInstall = [
+          "build/${platform}/release/bl2.img"
+          "build/${platform}/release/bl31.bin"
+        ];
+      };
+      armTrustedFirmwareRAM = pkgs.buildArmTrustedFirmware rec {
+        src = armTrustedFirmwareSrc;
+        version = armTrustedFirmwareVersion;
+        prePatch = applyArmTrustedFirmwarePatches;
+        extraMakeFlags = tfaMakeFlags ++ [
+          "BOOT_DEVICE=ram"
+          "RAM_BOOT_UART_DL=1"
+          "bl2"
+        ];
+        platform = tfaPlatform;
+        extraMeta.platforms = [ "aarch64-linux" ];
+        filesToInstall = [
+          "build/${platform}/release/bl2.bin"
+        ];
+      };
+    in
+    pkgs.stdenv.mkDerivation {
+      name = "bootloader";
+      src = ./.;
+      installPhase = ''
+        mkdir -p $out
+        cp ${armTrustedFirmwareFlash}/bl2.img ${uboot}/u-boot.bin $out
+        cp ${armTrustedFirmwareRAM}/bl2.bin $out/bl2-ram.bin
+
+        ${pkgs.buildPackages.armTrustedFirmwareTools}/bin/fiptool create \
+          --soc-fw ${armTrustedFirmwareFlash}/bl31.bin \
+          --nt-fw ${uboot}/u-boot.bin \
+          $out/u-boot.fip
+
+        cat > $out/boot.scr << EOF
+        setenv serverip ${serverip}
+        setenv ipaddr ${ipaddr}
+        tftpboot 0x${lib.toHexString loadAddress} result/u-boot.bin
+        go 0x${lib.toHexString loadAddress}
+        EOF
+
+        cat > $out/uartboot.sh << EOF
+        #!/bin/sh
+
+        ${pkgs.buildPackages.mtk-uartboot}/bin/mtk_uartboot --aarch64 \
+          --brom-load-baudrate 115200 \
+          --bl2-load-baudrate 115200 \
+          -s "\$1" \
+          -p $out/bl2-ram.bin \
+          -f $out/u-boot.fip
+        EOF
+        chmod +x $out/uartboot.sh
+
+        cat > $out/flash.scr << EOF
+        setenv serverip ${serverip}
+        setenv ipaddr ${ipaddr}
+        setenv bootfile_bl2 result/bl2.img
+        setenv bootfile_fip result/u-boot.fip
+        run boot_tftp_write_bl2
+        run boot_tftp_write_fip
+        EOF
+      '';
+    };
 }


### PR DESCRIPTION
The #26 proposal relies on a fix for a U-Boot bug, so we may need to ask users to flash a new bootloader in order to use the new recovery system. Therefore, add an output to the openwrt-one device that builds a bootloader with the bug fix, and add instructions for building, booting and flashing the bootloader using the new output.

Since we now need to build our own bootloader, let's also do a couple of things:

1. Enable KASLR support via a recently landed TF-A change: https://github.com/mtk-openwrt/arm-trusted-firmware/pull/22

2. Make it more convenient to configure the system to boot Liminix by building the environment variable update into the U-Boot binary (which will change with the new recovery system).