### PR TITLE
Adjust kernel exploit mitigation settings on arm64

### DIFF
--- a/modules/arch/aarch64.nix
+++ b/modules/arch/aarch64.nix
@@ -16,6 +16,9 @@
 
       OF = "y";
       # USE_OF = "y";
+
+      ARM64_PTR_AUTH = "n";
+      RANDOMIZE_BASE = "y";
     };
     hardware.ram.startAddress = lim.parseInt "0x40000000";
     system.outputs.u-boot = pkgs.ubootQemuAarch64;


### PR DESCRIPTION
CONFIG_RANDOMIZE_BASE enables KASLR. It doesn't increase the size of the kernel image for OpenWrt One (technically it increases .text size by 256 bytes, but that was cancelled out by alignment padding). Set this to y on arm64. The other architectures are not modified (arm doesn't support it, and mips only supports it for some targets).

CONFIG_ARM64_PTR_AUTH is enabled by default by the kernel and enables pointer authentication instructions at entry and exit of most kernel functions. However, none of our targets support pointer authentication, so these instructions are just taking up space for no purpose. Set this one to n, which reduces OpenWrt One kernel image size by 24KB.