### PR TITLE
fix: make Lua SYSLIBS platform-conditional for macOS compatibility

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -12,7 +12,7 @@ let
       l = prev.lua5_3.overrideAttrs (o: {
         name = "lua-tty";
         preBuild = ''
-          makeFlagsArray+=(PLAT="posix" SYSLIBS="-Wl,-E -ldl"  CFLAGS="-O2 -fPIC -DLUA_USE_POSIX -DLUA_USE_DLOPEN")
+          makeFlagsArray+=(PLAT="posix" SYSLIBS="${if final.stdenv.isDarwin then "" else "-Wl,-E "}-ldl"  CFLAGS="-O2 -fPIC -DLUA_USE_POSIX -DLUA_USE_DLOPEN")
         '';
         # lua in nixpkgs has a postInstall stanza that assumes only
         # one output, we need to override that if we're going to


### PR DESCRIPTION
Fixes #32

## Problem

The Lua 5.3 build in `overlay.nix` hardcodes `-Wl,-E` (GNU ld's `--export-dynamic`), which Apple's ld64 rejects with `ld: unknown option: -E`. This cascades to fail the doc build and anything else that transitively depends on Lua.

## Fix

Make the flag platform-conditional — macOS dyld handles dynamic symbol visibility differently and doesn't need `-Wl,-E`:

```diff
- makeFlagsArray+=(PLAT="posix" SYSLIBS="-Wl,-E -ldl" ...)
+ makeFlagsArray+=(PLAT="posix" SYSLIBS="${if final.stdenv.isDarwin then "" else "-Wl,-E "}-ldl" ...)
```